### PR TITLE
Bump Microsoft.Extensions.DependencyInjection.Abstractions in /Solutions

### DIFF
--- a/Solutions/Corvus.Extensions.System.Text.Json/Corvus.Extensions.System.Text.Json.csproj
+++ b/Solutions/Corvus.Extensions.System.Text.Json/Corvus.Extensions.System.Text.Json.csproj
@@ -18,7 +18,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.12" />
     <PackageReference Include="System.Text.Json" Version="4.7.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Replacement for #89 to get around long name issue in build.

Bumps [Microsoft.Extensions.DependencyInjection.Abstractions](https://github.com/aspnet/Extensions) from 2.2.0 to 3.1.12.
- [Release notes](https://github.com/aspnet/Extensions/releases)
- [Commits](https://github.com/aspnet/Extensions/compare/2.2.0...v3.1.12)

Signed-off-by: dependabot[bot] <support@github.com>