### PR TITLE
Prevent long dependabot branch names from breaking build

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -4,5 +4,24 @@ branches:
     regex: ^master
     tag: preview
     increment: patch
+  dependabot-pr:
+    mode: ContinuousDeployment
+    tag: dependabot
+    increment: Inherit
+    prevent-increment-of-merged-branch-version: false
+    tag-number-pattern: '[/-](?<number>\d+)'
+    track-merge-target: false
+    regex: ^dependabot
+    source-branches:
+    - develop
+    - master
+    - release
+    - feature
+    - support
+    - hotfix
+    tracks-release-branches: false
+    is-release-branch: false
+    is-mainline: false
+    pre-release-weight: 30000
 next-version: "1.0"
 


### PR DESCRIPTION
Dependabot creates branches with quite long names such as `dependabot/nuget/Solutions/Microsoft.Extensions.DependencyInjection.Abstractions-3.1.12`. This causes builds to fail because we derive the SemVer pre-release tag from the branch name, and it ends up being too long.

For human-defined branch names, it is useful to have the branch name to become the pre-release tag, so that if we do a preview release from a feature branch, it's easy to recognize the right release. (E.g., in NuGet, you might use the `Corvus.Ignition` version `1.0.1-prevent-spontaneous-combustion.4` to use a preview from the `feature/prevent-spontaneous-combustion` branch.)

But dependabot's very long generated branch names result in correspondingly very long pre-release tags, such as `dependabot-nuget-Solutions-Microsoft.Extensions.DependencyInjection.Abstractions-3.1.12.9`. That's 89 characters long. When you combine this with a fairly long package name such as `Corvus.Extensions.System.Text.Json` and the `.nupkg` file extension, you get up to even longer filenames, such as `Corvus.Extensions.System.Text.Json.1.0.1-dependabot-nuget-Solutions-Microsoft-Extensions-DependencyInjection-Abstractions-3-1-12.9.nupkg` (136 characters).

The problem we then run into is that NuGet tries to embed OpenXML core properties with a long-ish filename inside the package, e.g. `package/services/metadata/core-properties/53f9c0140fc5470e806af6d51cbf38e2.psmdcp`. This then causes it to fail a validation check. The `PathTooLongRule` check in NuGet checks that the path length you end up with when unzipping a `.nupkg` (and assuming you don't rename it) will be no longer than 200 characters.

In this example, it determines that unzipping the package will produce a file named:

`Corvus.Extensions.System.Text.Json.1.0.1-dependabot-nuget-Solutions-Microsoft-Extensions-DependencyInjection-Abstractions-3-1-12.9/package/services/metadata/core-properties/53f9c0140fc5470e806af6d51cbf38e2.psmdcp`

That's 212 characters long (and that's before we get to any absolute path on the front). This fails the test, and we get an NU5123 warning as a result.

This PR modifies `GitVersion.yml` to recognize dependabot PRs and use a shorter pre-release tag. The tag will not be unique, but it doesn't matter because we never build released components in these PRs. The build is only there to verify that successful builds are possible.